### PR TITLE
Hand over path instead of file name

### DIFF
--- a/src/ML-RUNNER/pair_runner.cpp
+++ b/src/ML-RUNNER/pair_runner.cpp
@@ -381,9 +381,9 @@ void PairRUNNER::coeff(int narg, char **arg)
   // Returns max cutoff for LAMMPS neighborlist.
   // Also returns booleans if additional atomic properties are predicted,
   // which need to be communicated between local and ghost atoms.
-  std::string finputnn = "input.nn";
-  int n_input_nn_len = strlen(finputnn.c_str());
-  runner_lammps_interface_init(finputnn.c_str(),&n_input_nn_len, &cutoff,
+  std::string path = "." // TODO: get path from LAMMPS
+  int n_path_len = strlen(finputnn.c_str());
+  runner_lammps_interface_init(finputnn.c_str(),&n_path_len, &cutoff,
     &comm->me, &nnpGeneration, &lHirshfeldVdw);
 
 }


### PR DESCRIPTION
As discussed in the meeting, the runner interfaces expects a path not a filename. 